### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/backend/src/infrastructure/routes/social_media/view.py
+++ b/backend/src/infrastructure/routes/social_media/view.py
@@ -31,6 +31,6 @@ class SocialMediaLinks(Resource):
         except Exception as error:
             logger.error(f"Error getting social media: {str(error)}")
             return (
-                jsonify({"error": "Internal server error", "message": str(error)}),
+                jsonify({"error": "Internal server error", "message": "An unexpected error occurred. Please try again later."}),
                 HTTP_INTERNAL_SERVER_ERROR,
             )


### PR DESCRIPTION
Potential fix for [https://github.com/ivanildobarauna-dev/ivanildobarauna.dev/security/code-scanning/5](https://github.com/ivanildobarauna-dev/ivanildobarauna.dev/security/code-scanning/5)

To fix the issue, we will modify the code to ensure that detailed exception information is not exposed to the client. Instead, we will log the detailed error message using the existing `logger` and return a generic error message to the client. This approach ensures that developers can still access the detailed error information for debugging purposes while protecting sensitive information from being exposed to users.

Specifically:
1. Replace the `str(error)` in the response body with a generic error message.
2. Ensure that the detailed error message is logged using the `logger`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
