### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Run backend tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ivanildobarauna-dev/ivanildobarauna.dev/security/code-scanning/1](https://github.com/ivanildobarauna-dev/ivanildobarauna.dev/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the current workflow. This ensures that the workflow has the minimum required permissions and avoids granting unnecessary write access.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
