### PR TITLE
Atualiza READMEs e cria setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Este repositório contempla o código fonte do site [ivanildobarauna.dev](https:
 
 Ambos os projetos possuem Dockerfile próprio e podem ser executados de forma integrada via Docker Compose.
 
+Para instalar todas as dependências em um único passo, utilize o script `setup.sh` na raiz do repositório:
+
+```bash
+./setup.sh
+```
+
 ## Estrutura do repositório
 
 ```

--- a/backend/README.md
+++ b/backend/README.md
@@ -92,13 +92,15 @@ Este projeto utiliza a **Arquitetura Hexagonal** (também conhecida como Ports a
 
 ### Configuração do Ambiente
 
+Para executar o backend localmente, é necessário instalar as dependências com o [Poetry](https://python-poetry.org/). Caso prefira `pip`, utilize o arquivo `requirements.txt` gerado automaticamente pelo Poetry.
+
 ```bash
 # Clone o repositório
 git clone https://github.com/ivanildobarauna-dev/api.ivanildobarauna.dev.git
 cd api.ivanildobarauna.dev
 
 # Instale as dependências
-poetry install
+poetry install  # ou pip install -r requirements.txt
 
 # Ative o ambiente virtual
 poetry shell

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,6 +23,14 @@ docker-compose up --build
 
 Isso irá subir tanto o frontend quanto o backend integrados.
 
+## Instalação
+
+Para configurar o ambiente local e instalar as dependências execute:
+
+```bash
+npm install
+```
+
 ## Desenvolvimento local
 
 ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Instala dependências do backend via Poetry
+cd "$(dirname "$0")/backend" || exit 1
+poetry install || { echo 'Erro ao instalar dependências do backend'; exit 1; }
+
+# Instala dependências do frontend via npm
+cd ../frontend || exit 1
+npm install || { echo 'Erro ao instalar dependências do frontend'; exit 1; }
+
+cd ..
+echo "Ambiente configurado com sucesso."


### PR DESCRIPTION
## Resumo
- adiciona script `setup.sh` para instalacao de dependencias
- atualiza instrucoes de instalacao no README principal
- adiciona sessao de instalacao em `backend/README.md`
- adiciona sessao de instalacao em `frontend/README.md`

## Testes realizados
- `poetry run pytest`
- `npm test` *(falhou)*

------
https://chatgpt.com/codex/tasks/task_e_683f6bfbec4c832bb0611dfe19d891eb