### PR TITLE
Improve projects tests

### DIFF
--- a/backend/src/infrastructure/routes/projects/view.py
+++ b/backend/src/infrastructure/routes/projects/view.py
@@ -1,7 +1,7 @@
 """Projects Routes"""
 
-from flask import Blueprint, jsonify
-from flask_restx import Resource, Namespace
+from flask import Blueprint
+from flask_restx import Namespace, Resource
 
 from src.infrastructure.application_dependencies import portfolio_data_service
 from src.infrastructure.utils.constants import HTTP_INTERNAL_SERVER_ERROR
@@ -23,10 +23,9 @@ class Projects(Resource):
 
             response = [project.to_dict() for project in projects if project.active]
 
-            return jsonify(response)
+            return response
         except Exception as error:
             logger.error(f"Error getting projects: {str(error)}")
-            return (
-                jsonify({"error_message": "An internal server error occurred"}),
-                HTTP_INTERNAL_SERVER_ERROR
-            )
+            return {
+                "error_message": "An internal server error occurred"
+            }, HTTP_INTERNAL_SERVER_ERROR

--- a/backend/tests/infrastructure/routes/projects/test_view.py
+++ b/backend/tests/infrastructure/routes/projects/test_view.py
@@ -20,6 +20,8 @@ def test_get_projects_returns_active_projects(
         
         assert response.status_code == 200
         data = json.loads(response.data)
+        assert len(data) == len(sample_projects)
+        assert data[0]["title"] == sample_projects[0].title
 
 
 def test_get_projects_error_handling(client, mock_portfolio_service):
@@ -34,3 +36,4 @@ def test_get_projects_error_handling(client, mock_portfolio_service):
         
         assert response.status_code == HTTP_INTERNAL_SERVER_ERROR
         data = json.loads(response.data)
+        assert "error_message" in data


### PR DESCRIPTION
## Summary
- cover active projects fields in tests
- ensure error response includes error_message
- fix projects route to return serializable dicts

## Testing
- `poetry run ruff src/infrastructure/routes/projects/view.py`
- `poetry run ruff tests/infrastructure/routes/projects/test_view.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6bb7d224832b9528d091d8505cc4