### PR TITLE
Implement retry strategy for frontend API calls

### DIFF
--- a/frontend/src/app/education/hooks/useEducation.ts
+++ b/frontend/src/app/education/hooks/useEducation.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Formation, Certification } from '../interfaces';
 import { getBackendEndpoint } from '@/utils/backend_endpoint';
+import { retryAsync } from '@/utils/retryAsync';
 
 interface EducationData {
   formations: Formation[];
@@ -20,27 +21,31 @@ export function useEducation(): EducationData {
       const educationEndpoint = getBackendEndpoint('/education');
 
       try {
-        const response = await fetch(`${educationEndpoint}`, {
-          method: 'GET',
-          headers: {
-            'Accept': 'application/json',
-          },
-          mode: 'cors',
+        const data = await retryAsync(async () => {
+          const response = await fetch(`${educationEndpoint}`, {
+            method: 'GET',
+            headers: {
+              'Accept': 'application/json',
+            },
+            mode: 'cors',
+          });
+
+          if (!response.ok) {
+            console.error(`Erro na requisição: Status ${response.status}`);
+            const responseText = await response.text();
+            console.error('Resposta do servidor:', responseText);
+            throw new Error(`Falha ao carregar os dados de educação. Status: ${response.status}`);
+          }
+
+          const jsonData = await response.json();
+
+          if (!jsonData.formations || !jsonData.certifications || !Array.isArray(jsonData.formations) || !Array.isArray(jsonData.certifications)) {
+            throw new Error('Resposta inválida: os dados não estão no formato esperado');
+          }
+
+          return jsonData as { formations: Formation[]; certifications: Certification[] };
         });
 
-        if (!response.ok) {
-          console.error(`Erro na requisição: Status ${response.status}`);
-          const responseText = await response.text();
-          console.error('Resposta do servidor:', responseText);
-          throw new Error(`Falha ao carregar os dados de educação. Status: ${response.status}`);
-        }
-        
-        const data = await response.json();
-        
-        if (!data.formations || !data.certifications || !Array.isArray(data.formations) || !Array.isArray(data.certifications)) {
-          throw new Error('Resposta inválida: os dados não estão no formato esperado');
-        }
-        
         // No need to map formations as the format is already compatible
         setFormations(data.formations);
         setCertifications(data.certifications);

--- a/frontend/src/app/education/hooks/useTotalEducation.ts
+++ b/frontend/src/app/education/hooks/useTotalEducation.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { getBackendEndpoint } from '@/utils/backend_endpoint';
+import { retryAsync } from '@/utils/retryAsync';
 
 interface TotalEducationData {
   totalEducation: string;
@@ -17,26 +18,30 @@ export function useTotalEducation(): TotalEducationData {
       try {
         const educationEndpoint = getBackendEndpoint('/education');
 
-        const response = await fetch(educationEndpoint, {
-          method: 'GET',
-          headers: {
-            'Accept': 'application/json',
-          },
-          mode: 'cors',
-        });
+        const data = await retryAsync(async () => {
+          const response = await fetch(educationEndpoint, {
+            method: 'GET',
+            headers: {
+              'Accept': 'application/json',
+            },
+            mode: 'cors',
+          });
 
-        if (!response.ok) {
-          console.error(`Erro na requisição: Status ${response.status}`);
-          const responseText = await response.text();
-          console.error('Resposta do servidor:', responseText);
-          throw new Error(`Falha ao carregar os dados de educação. Status: ${response.status}`);
-        }
-        
-        const data = await response.json();
-        
-        if (!data.formations || !data.certifications || !Array.isArray(data.formations) || !Array.isArray(data.certifications)) {
-          throw new Error('Resposta inválida: os dados não estão no formato esperado');
-        }
+          if (!response.ok) {
+            console.error(`Erro na requisição: Status ${response.status}`);
+            const responseText = await response.text();
+            console.error('Resposta do servidor:', responseText);
+            throw new Error(`Falha ao carregar os dados de educação. Status: ${response.status}`);
+          }
+
+          const jsonData = await response.json();
+
+          if (!jsonData.formations || !jsonData.certifications || !Array.isArray(jsonData.formations) || !Array.isArray(jsonData.certifications)) {
+            throw new Error('Resposta inválida: os dados não estão no formato esperado');
+          }
+
+          return jsonData as { formations: unknown[]; certifications: unknown[] };
+        });
 
         const total = data.formations.length + data.certifications.length;
         setTotalEducation(`${total}+`);

--- a/frontend/src/app/projects/hooks/useTotalProjects.ts
+++ b/frontend/src/app/projects/hooks/useTotalProjects.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { getBackendEndpoint } from '@/utils/backend_endpoint';
+import { retryAsync } from '@/utils/retryAsync';
 
 interface TotalProjectsData {
   totalProjects: string;
@@ -17,26 +18,30 @@ export function useTotalProjects(): TotalProjectsData {
       try {
         const projectsEndpoint = getBackendEndpoint('/projects');
 
-        const response = await fetch(projectsEndpoint, {
-          method: 'GET',
-          headers: {
-            'Accept': 'application/json',
-          },
-          mode: 'cors',
-        });
+        const data = await retryAsync(async () => {
+          const response = await fetch(projectsEndpoint, {
+            method: 'GET',
+            headers: {
+              'Accept': 'application/json',
+            },
+            mode: 'cors',
+          });
 
-        if (!response.ok) {
-          console.error(`Erro na requisição: Status ${response.status}`);
-          const responseText = await response.text();
-          console.error('Resposta do servidor:', responseText);
-          throw new Error(`Falha ao carregar os projetos. Status: ${response.status}`);
-        }
-        
-        const data = await response.json();
-        
-        if (!Array.isArray(data)) {
-          throw new Error('Resposta inválida: os dados não são um array');
-        }
+          if (!response.ok) {
+            console.error(`Erro na requisição: Status ${response.status}`);
+            const responseText = await response.text();
+            console.error('Resposta do servidor:', responseText);
+            throw new Error(`Falha ao carregar os projetos. Status: ${response.status}`);
+          }
+
+          const jsonData = await response.json();
+
+          if (!Array.isArray(jsonData)) {
+            throw new Error('Resposta inválida: os dados não são um array');
+          }
+
+          return jsonData as unknown[];
+        });
 
         setTotalProjects(`${data.length}+`);
       } catch (error: unknown) {

--- a/frontend/src/app/social-links/hooks/useSocialLinks.ts
+++ b/frontend/src/app/social-links/hooks/useSocialLinks.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { SocialLink } from '../interfaces';
 import { getBackendEndpoint } from '@/utils/backend_endpoint';
+import { retryAsync } from '@/utils/retryAsync';
 
 interface SocialLinksData {
   socialLinks: SocialLink[];
@@ -18,27 +19,31 @@ export function useSocialLinks(): SocialLinksData {
       try {
         const socialLinksEndpoint = getBackendEndpoint('/social-media-links');
 
-        const response = await fetch(`${socialLinksEndpoint}`, {
-          method: 'GET',
-          headers: {
-            'Accept': 'application/json',
-          },
-          mode: 'cors',
+        const data = await retryAsync(async () => {
+          const response = await fetch(`${socialLinksEndpoint}`, {
+            method: 'GET',
+            headers: {
+              'Accept': 'application/json',
+            },
+            mode: 'cors',
+          });
+
+          if (!response.ok) {
+            console.error(`Erro na requisição: Status ${response.status}`);
+            const responseText = await response.text();
+            console.error('Resposta do servidor:', responseText);
+            throw new Error(`Falha ao carregar os links sociais. Status: ${response.status}`);
+          }
+
+          const jsonData = await response.json();
+
+          if (!Array.isArray(jsonData)) {
+            throw new Error('Resposta inválida: os dados não são um array');
+          }
+
+          return jsonData as SocialLink[];
         });
 
-        if (!response.ok) {
-          console.error(`Erro na requisição: Status ${response.status}`);
-          const responseText = await response.text();
-          console.error('Resposta do servidor:', responseText);
-          throw new Error(`Falha ao carregar os links sociais. Status: ${response.status}`);
-        }
-        
-        const data = await response.json();
-        
-        if (!Array.isArray(data)) {
-          throw new Error('Resposta inválida: os dados não são um array');
-        }
-        
         setSocialLinks(data);
       } catch (error: unknown) {
         if (error instanceof Error) {

--- a/frontend/src/test/retryAsync.test.ts
+++ b/frontend/src/test/retryAsync.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Tests for the retryAsync utility function.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { retryAsync } from '../utils/retryAsync';
+
+describe('retryAsync', () => {
+  it('should resolve after retries succeed', async () => {
+    let attempts = 0;
+    const task = vi.fn().mockImplementation(() => {
+      attempts++;
+      if (attempts < 3) {
+        return Promise.reject(new Error('fail'));
+      }
+      return Promise.resolve('ok');
+    });
+
+    const result = await retryAsync(task, 3, 10);
+    expect(result).toBe('ok');
+    expect(task).toHaveBeenCalledTimes(3);
+  });
+
+  it('should throw the last error after exhausting attempts', async () => {
+    const task = vi.fn().mockRejectedValue(new Error('fail'));
+
+    await expect(retryAsync(task, 3, 10)).rejects.toThrow('fail');
+    expect(task).toHaveBeenCalledTimes(3);
+  });
+});

--- a/frontend/src/utils/retryAsync.ts
+++ b/frontend/src/utils/retryAsync.ts
@@ -1,0 +1,31 @@
+/**
+ * Utility function that executes an asynchronous task with linear retry logic.
+ * It retries the provided function up to `attempts` times, waiting `delayMs`
+ * milliseconds between attempts.
+ *
+ * @param fn - Asynchronous function to execute
+ * @param attempts - Total number of attempts, defaults to 3
+ * @param delayMs - Delay in milliseconds between attempts, defaults to 1000
+ * @returns The result of the asynchronous function
+ * @throws The last encountered error after exhausting all retries
+ */
+export async function retryAsync<T>(
+  fn: () => Promise<T>,
+  attempts = 3,
+  delayMs = 1000,
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (i < attempts - 1) {
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
+    }
+  }
+
+  throw lastError as Error;
+}


### PR DESCRIPTION
## Summary
- add generic `retryAsync` utility
- update frontend hooks to use `retryAsync`
- limit layout health check to three attempts
- test `retryAsync` behaviour

## Testing
- `npm run lint` *(fails: Unknown options error)*
- `npm run test` *(fails: backend endpoints unreachable and import errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f7f47c7d4832b90baa5a6cdacd38a