### PR TITLE
fix: Exclude infra/docs paths from rollback revert

### DIFF
--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -171,8 +171,12 @@ jobs:
           # Start from main HEAD (not from the tag)
           git checkout -b ${PR_BRANCH} main
 
-          # Replace all tracked files with the content from the rollback tag
+          # Replace application files with the content from the rollback tag,
+          # excluding infrastructure/docs paths (aligned with deploy paths-ignore)
           git checkout ${ROLLBACK_TAG} -- .
+
+          # Restore paths that should NOT be rolled back (same as deploy paths-ignore)
+          git checkout main -- .github/ docs/ tests/ README.md CHANGELOG.md LICENSE docker-compose.local.yaml '*.md' 2>/dev/null || true
 
           # Check if there are actual differences
           if git diff --cached --quiet && git diff --quiet; then


### PR DESCRIPTION
## Summary
- After reverting files to the rollback tag, restore infra/docs paths to main state
- Aligned with deploy `paths-ignore`: `.github/`, `docs/`, `tests/`, markdown files, `LICENSE`, `docker-compose.local.yaml`
- Prevents rollback from reverting workflow fixes, docs, and other non-application files

## Test plan
- [ ] Trigger rollback workflow and verify `.github/` files are not reverted
- [ ] Verify only application code (backend/, frontend/) is included in the rollback PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)