### PR TITLE
ci: use reusable tests-python-poetry workflow for backend

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -18,30 +18,8 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    
-    steps:
-    - uses: actions/checkout@v3
-    
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-        
-    - name: Install Poetry
-      uses: snok/install-poetry@v1
-      with:
-        version: 1.5.1
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-        
-    - name: Install dependencies
-      run: |
-        cd backend
-        poetry install --no-interaction
-        
-    - name: Run tests
-      run: |
-        cd backend
-        poetry run pytest
-        
+    uses: ivanildobarauna/github-workflows/.github/workflows/tests-python-poetry.yml@v1
+    with:
+      python-versions: '["3.11"]'
+      working-directory: backend
+      run-codecov: false


### PR DESCRIPTION
## Summary
- Replaces the previous `backend-tests.yml` content with a thin caller of `ivanildobarauna/github-workflows/.github/workflows/tests-python-poetry.yml@v1`.
- Behavior preserved: Python 3.11, working directory `backend`, no Codecov upload, same `paths-ignore` filters.

## Test plan
- [x] CI run on this PR (or a follow-up PR touching `backend/**`) is green