### PR TITLE
fix: lowercase image name for GHCR references

### DIFF
--- a/.github/workflows/docker-image-vps-deployment.yml
+++ b/.github/workflows/docker-image-vps-deployment.yml
@@ -17,7 +17,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-package:
@@ -33,6 +32,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Compute lowercase image name
+        run: |
+          LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_NAME=${LOWER}" >> "$GITHUB_ENV"
 
       - name: Compute next release version
         id: version


### PR DESCRIPTION
## Summary
After the owner rename to `IvanildoBarauna`, `${{ github.repository }}` returns `IvanildoBarauna/ivanildobarauna.dev` — Docker rejects this with `repository name must be lowercase` on pull. The previous build steps in `docker/build-push-action` happened to work (they push fine), but the VPS pull fails.

This PR moves `IMAGE_NAME` from a static `env:` to a runtime-computed lowercase value in the first step of `build-and-package`. All subsequent references (`docker/metadata-action`, `attest-build-provenance`, the `docker-compose.prod.yaml` heredoc) read the normalized value via `${{ env.IMAGE_NAME }}`.

## Failure being fixed
- Run: https://github.com/IvanildoBarauna/ivanildobarauna.dev/actions/runs/25815091826/job/75842222146
- Error: `unable to get image 'ghcr.io/IvanildoBarauna/ivanildobarauna.dev/frontend:1.0.9': Error response from daemon: invalid reference format: repository name (IvanildoBarauna/ivanildobarauna.dev/frontend) must be lowercase`

## Test plan
- [ ] Merge this PR
- [ ] Deploy run produces a new patch release (likely v1.0.10) and image refs render as `ghcr.io/ivanildobarauna/ivanildobarauna.dev/{frontend,backend}:...`
- [ ] Both containers come up on the VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)