### PR TITLE
ci: rollback workflow use reusable VPS deploy

### DIFF
--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -10,26 +10,27 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  rollback:
+  prepare-rollback:
+    name: Determine version and prepare rollback bundle
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      packages: read
-      pull-requests: write
-      id-token: write
-
+      contents: read
+    outputs:
+      rollback_version: ${{ steps.version.outputs.rollback_version }}
+      rollback_tag: ${{ steps.version.outputs.rollback_tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-          token: ${{ secrets.GH_PAT }}
+
+      - name: Compute lowercase image name
+        run: |
+          LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_NAME=${LOWER}" >> "$GITHUB_ENV"
 
       - name: Determine rollback version
+        id: version
         run: |
           if [ -n "${{ github.event.inputs.version }}" ]; then
             ROLLBACK_VERSION="${{ github.event.inputs.version }}"
@@ -42,31 +43,18 @@ jobs:
             echo "ERROR: Could not determine rollback version. No previous release found."
             exit 1
           fi
-          echo "ROLLBACK_VERSION=${ROLLBACK_VERSION}" >> $GITHUB_ENV
+          echo "rollback_version=${ROLLBACK_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "rollback_tag=v${ROLLBACK_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "ROLLBACK_VERSION=${ROLLBACK_VERSION}" >> "$GITHUB_ENV"
           echo "Rolling back to version: ${ROLLBACK_VERSION}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup SSH key
-        uses: webfactory/ssh-agent@v0.9.1
-        with:
-          ssh-private-key: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
-
-      - name: Add host to known hosts
+      - name: Prepare rollback bundle
         run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan -H ${{ secrets.VPS_SSH_HOST }} >> ~/.ssh/known_hosts
-
-      - name: Create rollback docker-compose
-        run: |
-          cat > docker-compose.rollback.yaml << 'EOF'
+          mkdir -p deploy
+          echo "DD_API_KEY=${{ secrets.DATADOG_API_KEY }}" > deploy/.env
+          cat > deploy/docker-compose.rollback.yaml << 'EOF'
           services:
             frontend:
               image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/frontend:${{ env.ROLLBACK_VERSION }}
@@ -127,41 +115,53 @@ jobs:
                 start_period: 60s
           EOF
 
-      - name: Create temporary .env file
-        run: |
-          echo "DD_API_KEY=${{ secrets.DATADOG_API_KEY }}" > .env
+      - name: Upload rollback bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-rollback-bundle
+          path: deploy/
+          retention-days: 1
 
-      - name: Sync rollback compose and env to VPS
-        run: |
-          rsync -avz --delete \
-            docker-compose.rollback.yaml .env \
-            ${{ secrets.VPS_SSH_USER }}@${{ secrets.VPS_SSH_HOST }}:/home/ubuntu/app/site/
+  deploy:
+    needs: prepare-rollback
+    uses: ivanildobarauna/github-workflows/.github/workflows/deploy-compose-ssh.yml@v1
+    with:
+      artifact-name: site-rollback-bundle
+      compose-file: docker-compose.rollback.yaml
+      remote-path: /home/ubuntu/app/site
+      environment: Production
+    secrets:
+      VPS_SSH_HOST: ${{ secrets.VPS_SSH_HOST }}
+      VPS_SSH_USER: ${{ secrets.VPS_SSH_USER }}
+      VPS_SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
 
-      - name: Deploy rollback version on VPS
-        run: |
-          ssh ${{ secrets.VPS_SSH_USER }}@${{ secrets.VPS_SSH_HOST }} << 'EOF'
-            cd /home/ubuntu/app/site
-            rm -f .env
-            echo "DD_API_KEY=${{ secrets.DATADOG_API_KEY }}" >> .env
-            docker compose -f docker-compose.rollback.yaml pull
-            docker compose -f docker-compose.rollback.yaml up -d --remove-orphans
-            docker system prune -f
-          EOF
+  post-rollback:
+    name: Mark release as latest and open revert PR
+    needs: [prepare-rollback, deploy]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      ROLLBACK_VERSION: ${{ needs.prepare-rollback.outputs.rollback_version }}
+      ROLLBACK_TAG: ${{ needs.prepare-rollback.outputs.rollback_tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ secrets.GH_PAT }}
 
       - name: Mark rollback release as latest
         run: |
-          ROLLBACK_TAG="v${ROLLBACK_VERSION}"
-
-          # Mark rollback version as latest (GitHub auto-removes latest from the previous one)
-          gh release edit ${ROLLBACK_TAG} --latest
-
+          gh release edit "${ROLLBACK_TAG}" --latest
           echo "Release ${ROLLBACK_TAG} marked as latest"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create rollback PR
         run: |
-          ROLLBACK_TAG="v${ROLLBACK_VERSION}"
           PR_BRANCH="rollback/${ROLLBACK_VERSION}"
 
           # Configure git identity for the revert commit
@@ -209,7 +209,3 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
-
-    environment:
-      name: Production
-      url: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}


### PR DESCRIPTION
## Summary
Refactors `.github/workflows/rollback.yml` to consume `ivanildobarauna/github-workflows/.github/workflows/deploy-compose-ssh.yml@v1`, mirroring what was done in #112 for the main deploy.

Now split into three jobs:
1. **`prepare-rollback`** — resolves the rollback version (from `workflow_dispatch` input or auto-picks the previous GitHub Release), generates `docker-compose.rollback.yaml` + `.env`, uploads as the `site-rollback-bundle` artifact. Exposes `rollback_version` and `rollback_tag` as outputs.
2. **`deploy`** — reusable call with `compose-file: docker-compose.rollback.yaml` and `remote-path: /home/ubuntu/app/site`.
3. **`post-rollback`** — marks the rollback release as `latest` and opens the revert PR against `main`. Same logic as before; only moved to its own job after the SSH deploy succeeds.

## Parity vs the previous workflow
Final state on the VPS and post-deploy actions are identical.

| Item | Before | After |
|---|---|---|
| `.env` rewrite via SSH after rsync | Yes (redundant) | Removed — bundled `.env` is the single source |
| `rsync --delete` | Present but no-op | Removed |
| `webfactory/ssh-agent` | `v0.9.1` | `v0.10.0` (via reusable) |
| `mkdir -p /home/ubuntu/app/site` | No (assumed existed) | Yes (idempotent, in reusable) |
| `docker login` in caller | Yes (unused — pulls happen on the VPS) | Removed |
| Lowercase `IMAGE_NAME` | No (would break on owner rename) | Yes (same fix from #114) |
| "Mark release as latest" + "Create rollback PR" | Inline | Moved to `post-rollback` job, gated on `needs: deploy` |
| Compose contents, Datadog vars, healthchecks | — | Unchanged |

## Required secrets (already configured in this repo)
- `DATADOG_API_KEY`
- `VPS_SSH_HOST`, `VPS_SSH_USER`, `VPS_SSH_PRIVATE_KEY`
- `GH_PAT` (for the `post-rollback` job — same as before)

## Test plan
- [ ] Merge this PR
- [ ] Trigger `workflow_dispatch` with empty version input (auto-detect)
- [ ] Verify rollback bundle artifact is created with the correct image refs (lowercase)
- [ ] Verify VPS pulls the previous version's images and containers come up healthy
- [ ] Verify the previous release is marked `latest` on GitHub
- [ ] Verify the rollback PR is opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)