### PR TITLE
fix: declare Production environment on post-rollback job

### DIFF
--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -139,6 +139,7 @@ jobs:
     name: Mark release as latest and open revert PR
     needs: [prepare-rollback, deploy]
     runs-on: ubuntu-latest
+    environment: Production
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
The `post-rollback` job introduced in #115 was missing `environment: Production`. Since `GH_PAT` is stored as an environment-scoped secret on `Production`, it was unreachable from the job, and `actions/checkout` received an empty token.

## Failure being fixed
\`\`\`
fatal: could not read Username for 'https://github.com': terminal prompts disabled
The process '/usr/bin/git' failed with exit code 128
\`\`\`

The deploy itself (SSH/rsync/compose) ran fine — the failure was strictly in the post-deploy housekeeping (mark release as latest + open revert PR).

## Why the original worked
The pre-#115 workflow was a single job with `environment: Production` at the job level, so all steps had access to environment secrets. When the workflow was split into three jobs, the deploy and post-rollback jobs needed to re-declare it. The reusable deploy already declared it via the `environment` input; only `post-rollback` was missing.

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger the rollback (`workflow_dispatch`)
- [ ] Verify `post-rollback` completes: release marked latest, revert PR opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)