### PR TITLE
fix: rollback use GITHUB_TOKEN instead of GH_PAT

### DIFF
--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -152,7 +152,6 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GH_PAT }}
 
       - name: Mark rollback release as latest
         run: |
@@ -209,4 +208,4 @@ jobs:
             echo "PR #${EXISTING_PR} already exists for this rollback"
           fi
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Replaces `secrets.GH_PAT` with the automatic `secrets.GITHUB_TOKEN` in the `post-rollback` job. GH_PAT was reaching the job (confirmed via debug logs showing the masked value) but produced `could not read Username for 'https://github.com'`, which means the value is present but invalid — most likely a fine-grained PAT that lost access when the repo owner was renamed.

## Why this works
The `post-rollback` job already declares the required permissions:
\`\`\`yaml
permissions:
  contents: write
  pull-requests: write
\`\`\`

`GITHUB_TOKEN` honors these to (a) push a new branch, (b) edit a release with `--latest`, and (c) create a pull request.

## Trade-off
PRs created with `GITHUB_TOKEN` don't trigger workflow runs on themselves (GitHub's anti-recursion guard). The rollback PR opened by this job won't have CI checks running until someone pushes a commit to its branch manually. For a manual revert PR this is usually fine — you'll review locally and either merge or push a tweak that re-triggers CI.

## Test plan
- [ ] Merge this PR
- [ ] Trigger Rollback workflow again (`workflow_dispatch`)
- [ ] Verify `post-rollback` completes: previous release marked latest, revert branch pushed, rollback PR opened

## Follow-up
The `GH_PAT` repo secret is no longer used by any workflow in this repo. Consider deleting it from Settings → Secrets and variables → Actions to avoid confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)